### PR TITLE
High Value Accounts

### DIFF
--- a/PlayingWithApex/force-app/main/default/classes/AccountTriggerHandler.cls
+++ b/PlayingWithApex/force-app/main/default/classes/AccountTriggerHandler.cls
@@ -16,4 +16,22 @@ public with sharing class AccountTriggerHandler {
             accountsWithoutTypeCollection.add(acc);
         }
     }
+
+    /* If an account is updated to have an Annual Revenue greater than or equal to 5 million dollars;
+    then update the Description to read, "High Value Customer." */
+    
+    public static void highValueAccounts(List<Account> accList, Map<Id, Account> oldMap) {
+
+        List<Account> highValueAccountsCollection = new List<Account>();
+
+        for (Account acc : accList) {
+            
+            Account oldAccount = oldMap.get(acc.Id);
+
+            if (oldAccount.AnnualRevenue != acc.AnnualRevenue && acc.AnnualRevenue != null && acc.AnnualRevenue >= 5000000) {
+                acc.Description = 'High Value Account';
+            }
+            highValueAccountsCollection.add(acc);
+        }
+    }
 }

--- a/PlayingWithApex/force-app/main/default/triggers/AccountTrigger.trigger
+++ b/PlayingWithApex/force-app/main/default/triggers/AccountTrigger.trigger
@@ -1,0 +1,11 @@
+trigger AccountTrigger on Account (before insert, before update) {
+	
+    if(Trigger.isInsert) {
+        AccountTriggerHandler.populateCustomerType(Trigger.new);
+    }
+    
+    if(Trigger.isUpdate) {
+        AccountTriggerHandler.highValueAccounts(Trigger.new, Trigger.oldMap);
+    }
+    
+}

--- a/PlayingWithApex/force-app/main/default/triggers/AccountTrigger.trigger-meta.xml
+++ b/PlayingWithApex/force-app/main/default/triggers/AccountTrigger.trigger-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <status>Active</status>
+</ApexTrigger>


### PR DESCRIPTION
Contains a new method within the AccountTriggerHandler called highValueAccounts. 
Contains a new before-update statement on the trigger file that calls highValueAccounts.

This method takes in a list of accounts and a map of old accounts (oldMap) and determines if there was a change in the annual revenue field. If there was and the annual revenue is over $5 million, then the method will update the description on the new account stating that this is a "High-Value Account."